### PR TITLE
Adds dark mode for options in dropdown

### DIFF
--- a/src/lib/components/tables/RowsPerPage.svelte
+++ b/src/lib/components/tables/RowsPerPage.svelte
@@ -11,7 +11,7 @@
     {#if !small}
         <span>{handler.i18n.show}</span>
     {/if}
-    <select bind:value={$rowsPerPage} on:change={() => handler.setPage(1)} class="m-2 h-8 p-1 pl-2 pr-6 text-xs text-black dark:text-white select-text bg-inherit">
+    <select bind:value={$rowsPerPage} on:change={() => handler.setPage(1)} class="m-2 h-8 p-1 pl-2 pr-6 text-xs text-black dark:text-white dark:bg-surface-900 select-text bg-inherit">
         {#each options as option}
             <option value={option}>
                 {option}


### PR DESCRIPTION
Fixes: https://github.com/mimamercury/mimamercury.com/issues/5

This seems to fix it on Windows, and doesn't seem to change anything on a Mac which was already working well.

![dropown with darkmode now](https://github.com/mimamercury/mimamercury.com/assets/1554630/4be3babb-4b81-4af5-bece-9571520ef07f)
